### PR TITLE
user input for CIs

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,3 +19,8 @@ Now only scrap IPS docs as an example.
 # install
 Normal nodejs project
 You are at your own.
+
+# usage
+	$ npm start 7000000
+
+*7.000.000 and down is the CIs do you want to take*

--- a/config.js
+++ b/config.js
@@ -27,8 +27,8 @@ config.ci = '0';
 config.bodyTrailer = '&recuperar=Recuperar&envio=ok';
 
 config.outputFile = 'ips.txt';
-
-config.totalCI = 7000000;
+// 7000000 CIs and down
+config.totalCI = process.argv[2];
 config.queue = 150;
 
 module.exports = config;


### PR DESCRIPTION
Es solo para ingresar manualmente la cantidad de CIs desde la consola, decime que te parece @luchobenitez
